### PR TITLE
Allow Ctrl-b to work in nested tmux

### DIFF
--- a/inactive-row.conf
+++ b/inactive-row.conf
@@ -1,8 +1,10 @@
 # Change the background color to unactive
 setw -g window-status-current-style bg=$inactive_window_bg
 
-# Unbind prefix
-set -u -g prefix C-a
+# Unbind prefix (and "disable" by changing to something obscure)
+unbind C-a
+set -g prefix C-F12
+bind C-F12 send-prefix
 
 # Unbind each unprefixed command
 unbind -n M-left


### PR DESCRIPTION
When starting a nested tmux, do not revert the tmux prefix in the parent
tmux to the default (C-b) as it intercepts Ctrl-b from the nested tmux.
Instead, bind the tmux prefix to C-F12, which is unlikely to be used and
parallels the M-F12 binding used for active handler.

For example, to reproduce the problem:

1) Start tmux
2) Start vim in paraent tmux
   - Ctrl-f works to go forward a page
   - Ctrl-b works to go back a page
2) Create nested tmux (C-a C-s)
3) Start vim in nested tmux
   - Ctrl-f works to go forward a page
   - Ctrl-b does not work to go back a page