### PR TITLE
Parametrize paths (tmux 3.2/3+?), add navigation toggle

### DIFF
--- a/active-row.conf
+++ b/active-row.conf
@@ -28,7 +28,7 @@ set -g prefix C-a
 bind C-c new-window
 
 # Create a new nested tmux (Ctrl + A, Ctrl + s)
-bind C-s new-window ~/.tmux.conf.d/nested-tmux/new-tmux \; \
+bind C-s new-window "$aleclearmind_nested_tmux_root"/new-tmux \; \
          rename-window '' \; \
          command-prompt -I "#W" "rename-window -- '%%'"
 
@@ -55,21 +55,24 @@ bind -n M-left  prev
 # Create new window (Ctrl + t)
 bind -n C-t new-window
 
+# Disable unprefixed (this is a toggle in that inactive binds to to make active)
+bind -n M-c source-file "$aleclearmind_nested_tmux_root"/toggle-inactive-row.conf
+
 # Switch to inner tmux (Alt + Up)
 bind -n M-up send-keys M-F12
 
 # Switch to outer tmux (Alt + Down)
-bind -n M-down source-file ~/.tmux.conf.d/nested-tmux/inactive-row.conf \; \
-               run-shell 'tmux -L $TMUX_PARENT source-file ~/.tmux.conf.d/nested-tmux/active-row.conf' \; \
+bind -n M-down source-file "$aleclearmind_nested_tmux_root"/inactive-row.conf \; \
+               run-shell 'tmux -L $TMUX_PARENT source-file "$aleclearmind_nested_tmux_root"/active-row.conf' \; \
                run-shell 'tmux -L $TMUX_PARENT set -g window-status-current-style bg=$active_window_bg'
 
 # Handler for becoming active (Alt + F12, don't use directly)
-bind -n M-F12 run-shell 'tmux -L $TMUX_PARENT source-file ~/.tmux.conf.d/nested-tmux/inactive-row.conf' \; \
-              source-file ~/.tmux.conf.d/nested-tmux/active-row.conf \; \
+bind -n M-F12 run-shell 'tmux -L $TMUX_PARENT source-file "$aleclearmind_nested_tmux_root"/inactive-row.conf' \; \
+              source-file "$aleclearmind_nested_tmux_root"/active-row.conf \; \
               set -g window-status-current-style bg=$active_window_bg
 
 # Handler for closed window: enable outer terminal
-set-hook -g client-detached "run-shell 'tmux -L $TMUX_PARENT source-file ~/.tmux.conf.d/nested-tmux/active-row.conf && tmux -L $TMUX_PARENT set -g window-status-current-style bg=$active_window_bg'"
+set-hook -g client-detached "run-shell 'tmux -L $TMUX_PARENT source-file "$aleclearmind_nested_tmux_root"/active-row.conf && tmux -L $TMUX_PARENT set -g window-status-current-style bg=$active_window_bg'"
 
 #
 # Appearance
@@ -84,4 +87,4 @@ setw -g window-status-current-style bg=$active_window_bg
 if-shell 'test -z "$TMUX_PARENT"' 'bind -n M-down send-keys ""' ''
 
 # When a new session is created unbind the parent
-if-shell 'test -z "$TMUX_PARENT"' '' 'run-shell "tmux -L $TMUX_PARENT source-file ~/.tmux.conf.d/nested-tmux/inactive-row.conf"'
+if-shell 'test -z "$TMUX_PARENT"' '' 'run-shell "tmux -L $TMUX_PARENT source-file "$aleclearmind_nested_tmux_root"/inactive-row.conf"'

--- a/inactive-row-base.conf
+++ b/inactive-row-base.conf
@@ -1,0 +1,13 @@
+# Change the background color to unactive
+setw -g window-status-current-style bg=$inactive_window_bg
+
+# Unbind prefix
+set -u -g prefix C-a
+
+# Unbind each unprefixed command
+unbind -n M-left
+unbind -n M-right
+unbind -n M-up
+unbind -n M-down
+unbind -n C-t
+unbind -n M-c

--- a/inactive-row.conf
+++ b/inactive-row.conf
@@ -1,12 +1,4 @@
-# Change the background color to unactive
-setw -g window-status-current-style bg=$inactive_window_bg
+source "$aleclearmind_nested_tmux_root"/inactive-row-base.conf
 
-# Unbind prefix
-set -u -g prefix C-a
-
-# Unbind each unprefixed command
-unbind -n M-left
-unbind -n M-right
-unbind -n M-up
-unbind -n M-down
-unbind -n C-t
+# Unbind extra unprefixed command
+unbind -n M-c

--- a/new-tmux
+++ b/new-tmux
@@ -1,7 +1,7 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 TMUX_PARENT=$(basename "$TMUX")
 TMUX_PARENT="${TMUX_PARENT%%,*}"
 export TMUX_PARENT
 
-tmux -L "r$RANDOM"
+tmux -f "$THE_CONF_FILE" -L "r$RANDOM"

--- a/plugin.conf
+++ b/plugin.conf
@@ -1,0 +1,8 @@
+# WARNING the config_path and display only work since tmux 3.2; 
+# Make relative pathing usable
+setenv -gF aleclearmind_nested_tmux_root '#{d:current_file}'
+source -F '#{aleclearmind_nested_tmux_root}/active-row.conf'
+
+
+# Make new-tmux work #TODO better way to do this / $0 ? (i.e. how to self-call with params)
+setenv -gF THE_CONF_FILE '#{config_files}'

--- a/toggle-inactive-row.conf
+++ b/toggle-inactive-row.conf
@@ -1,0 +1,4 @@
+source "$aleclearmind_nested_tmux_root"/inactive-row-base.conf
+
+# Enable unprefixed
+bind -n M-c source-file "$aleclearmind_nested_tmux_root"/active-row.conf


### PR DESCRIPTION
This PR enables using nested-tmux without hardcoded paths, once the two patches in https://github.com/tmux/tmux/issues/2638 and https://github.com/tmux/tmux/issues/2637 land in upstream tmux.

It also makes the state machine more complicated, by allowing you to toggle the `M-arrow` navigation and the prefix with `M-c` (the binding is arbitrary).

With this, you can now easily test nested-tmux with a command like `tmux -f plugin.conf -L test`.

(Yes, I really should have used multiple commits for this.)