### PR TITLE
feat(tpm): Convert to a TPM plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,25 @@ This is a simple tmux configuration enabling to have arbitrarily many nested tmu
 
 # Quick start
 
+The easiest and recommended way to install is as a [TPM
+plugin](https://github.com/tmux-plugins/tpm#installation). Add this line to your
+`~/.tmux.conf`:
+
+```tmux
+set -g @plugin 'aleclearmind/nested-tmux'
+```
+
+Hit prefix + I to fetch the plugin and source it.
+
+Alternatively, install and use directly without TPM:
+
 ```
 mkdir ~/.tmux.conf.d/
 cd ~/.tmux.conf.d/
 git clone https://github.com/aleclearmind/nested-tmux.git
 mv ~/.tmux.conf ~/.tmux.conf.backup
-echo "source ~/.tmux.conf.d/nested-tmux/active-row.conf" > ~/.tmux.conf
+echo 'TPM_PLUGIN_DIR="~/.tmux.conf.d/nested-tmux"' > ~/.tmux.conf
+echo 'source "$TPM_PLUGIN_DIR/active-row.conf"' >> ~/.tmux.conf
 tmux
 ```
 

--- a/active-row.conf
+++ b/active-row.conf
@@ -28,7 +28,7 @@ set -g prefix C-a
 bind C-c new-window
 
 # Create a new nested tmux (Ctrl + A, Ctrl + s)
-bind C-s new-window ~/.tmux.conf.d/nested-tmux/new-tmux \; \
+bind C-s new-window "$TPM_PLUGIN_DIR/new-tmux" \; \
          rename-window '' \; \
          command-prompt -I "#W" "rename-window -- '%%'"
 
@@ -59,17 +59,17 @@ bind -n C-t new-window
 bind -n M-up send-keys M-F12
 
 # Switch to outer tmux (Alt + Down)
-bind -n M-down source-file ~/.tmux.conf.d/nested-tmux/inactive-row.conf \; \
-               run-shell 'tmux -L $TMUX_PARENT source-file ~/.tmux.conf.d/nested-tmux/active-row.conf' \; \
+bind -n M-down source-file "$TPM_PLUGIN_DIR/inactive-row.conf" \; \
+               run-shell 'tmux -L $TMUX_PARENT source-file "$TPM_PLUGIN_DIR/active-row.conf"' \; \
                run-shell 'tmux -L $TMUX_PARENT set -g window-status-current-style bg=$active_window_bg'
 
 # Handler for becoming active (Alt + F12, don't use directly)
-bind -n M-F12 run-shell 'tmux -L $TMUX_PARENT source-file ~/.tmux.conf.d/nested-tmux/inactive-row.conf' \; \
-              source-file ~/.tmux.conf.d/nested-tmux/active-row.conf \; \
+bind -n M-F12 run-shell 'tmux -L $TMUX_PARENT source-file "$TPM_PLUGIN_DIR/inactive-row.conf"' \; \
+              source-file "$TPM_PLUGIN_DIR/active-row.conf" \; \
               set -g window-status-current-style bg=$active_window_bg
 
 # Handler for closed window: enable outer terminal
-set-hook -g client-detached "run-shell 'tmux -L $TMUX_PARENT source-file ~/.tmux.conf.d/nested-tmux/active-row.conf && tmux -L $TMUX_PARENT set -g window-status-current-style bg=$active_window_bg'"
+set-hook -g client-detached "run-shell 'tmux -L $TMUX_PARENT source-file $TPM_PLUGIN_DIR/active-row.conf && tmux -L $TMUX_PARENT set -g window-status-current-style bg=$active_window_bg'"
 
 #
 # Appearance
@@ -84,4 +84,4 @@ setw -g window-status-current-style bg=$active_window_bg
 if-shell 'test -z "$TMUX_PARENT"' 'bind -n M-down send-keys ""' ''
 
 # When a new session is created unbind the parent
-if-shell 'test -z "$TMUX_PARENT"' '' 'run-shell "tmux -L $TMUX_PARENT source-file ~/.tmux.conf.d/nested-tmux/inactive-row.conf"'
+if-shell 'test -z "$TMUX_PARENT"' '' 'run-shell "tmux -L $TMUX_PARENT source-file $TPM_PLUGIN_DIR/inactive-row.conf"'

--- a/nested.tmux
+++ b/nested.tmux
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export TPM_PLUGIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+tmux source-file "${TPM_PLUGIN_DIR}/active-row.conf"


### PR DESCRIPTION
Add [the boilerplate necessary to use this project as a TPM plugin](https://github.com/tmux-plugins/tpm/blob/master/docs/how_to_create_plugin.md#2-create-a-tmux-plugin-run-file).  Works for me locally using `set -g @plugin 'file:///usr/local/src/nested-tmux'` and symlinking that into `~/.tmux/plugins/`.  IOW, I haven't tested this end-to-end but I'm not aware of any reason it shouldn't work.