### PR TITLE
fix(bindings): Avoid clobbering readline

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ tmux
 
 # Shortcuts
 
-* `Ctrl + a, Ctrl + c` or `Ctrl + t`: create a new window
-* `Ctrl + a, Ctrl + s`: create a new nested tmux session and ask a name for it
-* `Ctrl + a, Ctrl + A`: switch to last window
-* `Ctrl + a, A`: rename current window
+* `Ctrl + z, Ctrl + c` or `Ctrl + t`: create a new window
+* `Ctrl + z, Ctrl + s`: create a new nested tmux session and ask a name for it
+* `Ctrl + z, Ctrl + A`: switch to last window
+* `Ctrl + z, A`: rename current window
 * `Alt + Right`: move to the next window of the current row
 * `Alt + Left`: move to the previous window of the current row
 * `Alt + Up`: move to the inner tmux session

--- a/active-row.conf
+++ b/active-row.conf
@@ -56,9 +56,6 @@ bind -n M-right next
 # Go to previous window (Alt + Left)
 bind -n M-left  prev
 
-# Create new window (Ctrl + t)
-bind -n C-t new-window
-
 # Switch to inner tmux (Alt + Up)
 bind -n M-up send-keys M-F12
 

--- a/active-row.conf
+++ b/active-row.conf
@@ -36,8 +36,8 @@ bind C-s new-window ~/.tmux.conf.d/nested-tmux/new-tmux \; \
          rename-window '' \; \
          command-prompt -I "#W" "rename-window -- '%%'"
 
-# Switch to last window (Ctrl + z, Ctrl + z)
-bind C-a last-window
+# Switch to last window (Ctrl + z, Ctrl + e)
+bind C-e last-window
 
 # Rename current window (Ctrl + z, A)
 bind A  rename-window '' \; \

--- a/active-row.conf
+++ b/active-row.conf
@@ -18,24 +18,26 @@ set -g history-limit 100000
 # Configure prefix
 #
 unbind C-b
-set -g prefix C-a
+# Avoid clobbering common readline bindings which should be very fast, whereas
+# backgrounding a process is relatively incommon and the double-prefix is fine.
+set -g prefix C-z
 
 #
 # Prefixed commands
 #
 
-# Create a new window (Ctrl + A, Ctrl + c)
+# Create a new window (Ctrl + z, Ctrl + c)
 bind C-c new-window
 
-# Create a new nested tmux (Ctrl + A, Ctrl + s)
+# Create a new nested tmux (Ctrl + z, Ctrl + s)
 bind C-s new-window ~/.tmux.conf.d/nested-tmux/new-tmux \; \
          rename-window '' \; \
          command-prompt -I "#W" "rename-window -- '%%'"
 
-# Switch to last window (Ctrl + A, Ctrl + A)
+# Switch to last window (Ctrl + z, Ctrl + z)
 bind C-a last-window
 
-# Rename current window (Ctrl + A, A)
+# Rename current window (Ctrl + z, A)
 bind A  rename-window '' \; \
         command-prompt -I "#W" "rename-window -- '%%'"
 

--- a/active-row.conf
+++ b/active-row.conf
@@ -21,6 +21,8 @@ unbind C-b
 # Avoid clobbering common readline bindings which should be very fast, whereas
 # backgrounding a process is relatively incommon and the double-prefix is fine.
 set -g prefix C-z
+# Pass the prefix through (Ctrl + z, Ctrl + z)
+bind C-z send-prefix
 
 #
 # Prefixed commands

--- a/inactive-row.conf
+++ b/inactive-row.conf
@@ -2,7 +2,7 @@
 setw -g window-status-current-style bg=$inactive_window_bg
 
 # Unbind prefix
-set -u -g prefix C-a
+set -u -g prefix C-z
 
 # Unbind each unprefixed command
 unbind -n M-left


### PR DESCRIPTION
Readline provides a pretty powerful set of command-line searching and editing features
that can greatly increase CLI efficiency.  The readline library is also supported by
many interactive prompts, including language interactive REPLs.  Finally, many other
tools emulate readline bindings for similar tasks.  Given how frequently it can be used
and that it's used in the inner loop of command-line usage, its usage should be very
fast and as such every effort should be made to avoid adding any delay to it's bindings,
such as repeating the tmux prefix.  `Ctrl-a` is a particularly common and useful
readline binding, for example:

1. `Ctrl-r ...` to find a long command in shell history
2. `Ctrl-a` to jump to the beginning of the command
3. `M-f` to jump one word forward past the root command
4. Add a CLI option to the command
5. `RET` to run the command

Throughout my years with screen, tmux, various editors and rich readline usage, I've
tried a number of prefixes and I agree with many others that `Ctrl-z` is the best
prefix.  Suspending a process is an uncommon task relative to readline usage and the
double-prefix is fine for that task in my experience.
